### PR TITLE
Fix network key fetch loop

### DIFF
--- a/crates/ika-core/src/sui_connector/sui_syncer.rs
+++ b/crates/ika-core/src/sui_connector/sui_syncer.rs
@@ -254,9 +254,9 @@ where
                             key=?key_id,
                             current_epoch=?current_epoch,
                             error=?err,
-                            "failed to get network decryption key data, retrying...",
+                            "failed to get network decryption key data, skipping key",
                         );
-                        continue 'sync_network_keys;
+                        continue;
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- avoid aborting sync when one network key fails to fetch

## Testing
- `cargo fmt --all`
- `cargo test -p ika-core --no-run` *(failed: environment lacks dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688bc8043f20832786b3cc34fd838647